### PR TITLE
Ep gps uncertainty

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6315,6 +6315,7 @@
       <field type="float" name="ve" units="m/s">GPS velocity in east direction in earth-fixed NED frame</field>
       <field type="float" name="vd" units="m/s">GPS velocity in down direction in earth-fixed NED frame</field>
       <field type="float" name="speed_accuracy" units="m/s">GPS speed accuracy</field>
+      <field type="float" name="course_accuracy" units="rad">GPS course accuracy</field>
       <field type="float" name="horiz_accuracy" units="m">GPS horizontal accuracy</field>
       <field type="float" name="vert_accuracy" units="m">GPS vertical accuracy</field>
       <field type="float" name="heading_accuracy" units="rad">GPS heading accuracy</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6317,6 +6317,7 @@
       <field type="float" name="speed_accuracy" units="m/s">GPS speed accuracy</field>
       <field type="float" name="horiz_accuracy" units="m">GPS horizontal accuracy</field>
       <field type="float" name="vert_accuracy" units="m">GPS vertical accuracy</field>
+      <field type="float" name="heading_accuracy" units="rad">GPS heading accuracy</field>
       <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
       <extensions/>
       <field type="uint16_t" name="yaw" units="cdeg">Yaw of vehicle relative to Earth's North, zero means not available, use 36000 for north</field>


### PR DESCRIPTION
Solved Problem
No uncertainties provided with yaw or velocity GPS measurements.

Fixes #{Github issue ID}

Solution
Added course and heading (yaw) accuracy fields to the mavlink GPS messages (speed accuracy was already there)
Test coverage
Worked on Whitby.